### PR TITLE
Parameterized ensurability

### DIFF
--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -98,15 +98,8 @@ public class Event
 		/* Get the thread object (TID) for the calling thread */
 		Thread callingThread = Thread.getThis();
 
-		/* Lock the pipe-pairs */
-		pipesLock.lock();
-
-		/* Checks if a pipe-pair exists, if not creates it */
-		// TODO: Add a catch here, then unlock, rethrow
-		int[2] pipePair = pipeExistenceEnsure(callingThread);
-
-		/* Unlock the pipe-pairs */
-		pipesLock.unlock();
+		/* Ensure the calling thread */
+		ensure(callingThread);
 	}
 
 	// TODO: Add a version of the above which takes in a `Thread`
@@ -114,7 +107,15 @@ public class Event
 	// TODO: have the `ensure()` call this one and put all logic in here
 	public final void ensure(Thread thread)
 	{
-		// TODO: Implement me
+		/* Lock the pipe-pairs */
+		pipesLock.lock();
+
+		/* Checks if a pipe-pair exists, if not creates it */
+		// TODO: Add a catch here, then unlock, rethrow
+		int[2] pipePair = pipeExistenceEnsure(thread);
+
+		/* Unlock the pipe-pairs */
+		pipesLock.unlock();
 	}
 
 

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -103,7 +103,6 @@ public class Event
 		ensure(callingThread);
 	}
 
-	// TODO: have the `ensure()` call this one and put all logic in here
 	// TODO: DOcument exceptions
 
 	/** 

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -109,6 +109,14 @@ public class Event
 		pipesLock.unlock();
 	}
 
+	// TODO: Add a version of the above which takes in a `Thread`
+	// ... but do this on a branch other than `feature/interruptible`
+	// TODO: have the `ensure()` call this one and put all logic in here
+	public final void ensure(Thread thread)
+	{
+		// TODO: Implement me
+	}
+
 
 	// TODO: Make this a method we can call actually
 	private int[2] pipeExistenceEnsure(Thread thread)

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -123,7 +123,7 @@ public class Event
 	public final void ensure(Thread thread)
 	{
 		/* Checks if a pipe-pair exists, if not creates it */
-		pipeExistenceEnsure(callingThread);
+		pipeExistenceEnsure(thread);
 	}
 
 	/** 

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -539,7 +539,6 @@ unittest
 
 	writeln("Main thread is going to notify two threads");
 
-
 	// TODO: Add assert to check
 
 	/* Wake up all sleeping on this event */

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -90,7 +90,7 @@ public class Event
 	 *
 	 * This can be useful if one wants to initialize several
 	 * threads that should be able to all be notified and wake up
-	 * on their first call to wait instead of having wait
+	 * on their first call to wait instead of having `wait()`
 	 * ensure the pipe is created on first call.
 	 */
 	public final void ensure()

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -93,6 +93,7 @@ public class Event
 	 * on their first call to wait instead of having `wait()`
 	 * ensure the pipe is created on first call.
 	 */
+	// TODO: DOcument exceptions
 	public final void ensure()
 	{
 		/* Get the thread object (TID) for the calling thread */
@@ -102,9 +103,19 @@ public class Event
 		ensure(callingThread);
 	}
 
-	// TODO: Add a version of the above which takes in a `Thread`
-	// ... but do this on a branch other than `feature/interruptible`
 	// TODO: have the `ensure()` call this one and put all logic in here
+	// TODO: DOcument exceptions
+
+	/** 
+	 * Ensures the existence of a pipe-pair for the provided
+	 * thread. This is normally called before the thread in
+	 * question would await the `Event` and before another
+	 * thread, presumably the one calling `notify(Thread)`,
+	 * would ever start doing so.
+	 *
+	 * Params:
+	 *   thread = the `Thread` to ensure a pipe entry for
+	 */
 	public final void ensure(Thread thread)
 	{
 		/* Lock the pipe-pairs */


### PR DESCRIPTION
Let one call `ensure()` on behalf of another `Thread`, i.e.. by passing in the `Thread` in question.