### PR TITLE
Use scope guards

### DIFF
--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -110,9 +110,6 @@ public class Event
 		pipesLock.unlock();
 	}
 
-
-	// TODO: Make this a method we can call actually
-
 	/** 
 	 * Returns the pipe-pair for the mapped `Thread`
 	 * provided. if one does not exist then it is

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -287,15 +287,8 @@ public class Event
 		/* Get the thread object (TID) for the calling thread */
 		Thread callingThread = Thread.getThis();
 
-		/* Lock the pipe-pairs */
-		pipesLock.lock();
-
 		/* Checks if a pipe-pair exists, if not creates it */
-		// TODO: Add a catch here, then unlock, rethrow
 		int[2] pipePair = pipeExistenceEnsure(callingThread);
-
-		/* Unlock the pipe-pairs */
-		pipesLock.unlock();
 
 
 		/* Get the read-end of the pipe fd */

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -172,15 +172,8 @@ public class Event
 		/* Get the thread object (TID) for the calling thread */
 		Thread callingThread = Thread.getThis();
 
-		/* Lock the pipe-pairs */
-		pipesLock.lock();
-
 		/* Checks if a pipe-pair exists, if not creates it */
-		// TODO: Add a catch here, then unlock, rethrow
 		int[2] pipePair = pipeExistenceEnsure(callingThread);
-
-		/* Unlock the pipe-pairs */
-		pipesLock.unlock();
 
 
 		/* Get the read-end of the pipe fd */

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -99,15 +99,8 @@ public class Event
 		/* Get the thread object (TID) for the calling thread */
 		Thread callingThread = Thread.getThis();
 
-		/* Lock the pipe-pairs */
-		pipesLock.lock();
-
 		/* Checks if a pipe-pair exists, if not creates it */
-		// TODO: Add a catch here, then unlock, rethrow
-		int[2] pipePair = pipeExistenceEnsure(callingThread);
-
-		/* Unlock the pipe-pairs */
-		pipesLock.unlock();
+		pipeExistenceEnsure(callingThread);
 	}
 
 	/** 

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -93,6 +93,10 @@ public class Event
 	 * threads that should be able to all be notified and wake up
 	 * on their first call to wait instead of having wait
 	 * ensure the pipe is created on first call.
+	 *
+	 * Throws:
+	 *   `FatalException` on creating the pipe-pair
+	 * if needs be
 	 */
 	public final void ensure()
 	{

--- a/source/libsnooze/event.d
+++ b/source/libsnooze/event.d
@@ -132,18 +132,21 @@ public class Event
 		/* Lock the pipe-pairs */
 		pipesLock.lock();
 
+		/* On successful return or error */
+		scope(exit)
+		{
+			/* Unlock the pipe-pairs */
+			pipesLock.unlock();
+		}
+
 		/* If it is not in the pair, create a pipe-pair and save it */
 		if(!(thread in pipes))
 		{
-			// TODO: Add a catch here, then unlock then rethrow
-			pipes[thread] = newPipe();  //TODO: If bad (exception) use scopre guard too
+			pipes[thread] = newPipe();
 		}
 
 		/* Grab the pair */
 		pipePair = pipes[thread];
-
-		/* Unlock the pipe-pairs */
-		pipesLock.unlock();
 
 		return pipePair;
 	}


### PR DESCRIPTION
- `pipeExistenceEnsure(Thread)` now uses scope guards
- Removed now-completed TODOs in `pipeExistenceEnsure(Thread)`